### PR TITLE
feat: Robust multi-user process detection with tiered discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## 1.2.0 (2026-01-08)
+
+### Fixed
+- **Multi-user environment support**: Fixed process detection failing on shared Linux servers where multiple users run language_server processes. The extension now correctly identifies processes belonging to the current user.
+- **macOS argument truncation**: Fixed token extraction failing when `pgrep -fl` returns truncated command lines. Now performs targeted `ps -ww` re-queries to resolve full arguments.
+- **Windows CommandLine null handling**: Improved handling of processes with null/missing CommandLine in WMI output.
+
+### Added
+- **Tiered discovery**: Implements user-first, then global process search for better accuracy.
+- **Workspace-aware prioritization**: Prioritizes language server processes matching the current VS Code workspace.
+- **Multi-candidate iteration**: Tests multiple matching processes until finding a working one, instead of failing on the first candidate.
+
+### Changed
+- Refactored `platform_strategy` interface to support multi-tiered commands and multi-candidate parsing.
+- Refactored `ProcessFinder` for robust error handling and semantic exit code classification.
+
 ## 1.1.0 (2025-12-20)
 
 - Add absolute date and time to quota reset information (locale-aware)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ag-quota",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ag-quota",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ag-quota",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ag-quota",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ag-quota",
   "displayName": "Antigravity Quota (AGQ)",
   "description": "VS Code extension for the Antigravity IDE to monitor the usage of the models",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "henrikdev",
   "icon": "assets/AntiGravityQuota.png",
   "engines": {

--- a/src/core/platform_strategies.ts
+++ b/src/core/platform_strategies.ts
@@ -279,7 +279,7 @@ export class UnixStrategy implements platform_strategy {
 
 			// Extract port and token if available
 			const port_match = cmd.match(/--extension_server_port[=\s]+(\d+)/);
-			const token_match = cmd.match(/--csrf_token[=\s]+([a-zA-Z0-9\-]+)/);
+			const token_match = cmd.match(/--csrf_token[=\s]+([a-f0-9\-]+)/i);
 
 			// Return ALL PIDs, even if token is missing (crucial for macOS truncation)
 			candidates.push({
@@ -308,7 +308,7 @@ export class UnixStrategy implements platform_strategy {
 
 		const command_line = full_args.trim();
 		const port_match = command_line.match(/--extension_server_port[=\s]+(\d+)/);
-		const token_match = command_line.match(/--csrf_token[=\s]+([a-zA-Z0-9\-]+)/);
+		const token_match = command_line.match(/--csrf_token[=\s]+([a-f0-9\-]+)/i);
 
 		if (!token_match) {
 			return null;

--- a/src/core/platform_strategies.ts
+++ b/src/core/platform_strategies.ts
@@ -1,11 +1,25 @@
-import {logger} from '../utils/logger';
+import { logger } from '../utils/logger';
+
+// New candidate_info interface for multi-candidate support
+export interface candidate_info {
+	pid: number;
+	extension_port: number; // May be 0 if unparsed
+	csrf_token: string;     // May be "" if unparsed
+	command_line: string;   // May be "" if null/truncated
+}
 
 export interface platform_strategy {
-	get_process_list_command(process_name: string): string;
-	parse_process_info(stdout: string): {pid: number; extension_port: number; csrf_token: string} | null;
+	// New: Returns tiered commands for discovery
+	get_process_list_commands(process_name: string): { name: string; command: string }[];
+	// Changed: Returns array of candidates, MUST include PID even if args are missing
+	parse_process_info(stdout: string): candidate_info[];
+	// New: For targeted PID re-query (macOS/Windows truncation)
+	get_full_command_line_command(pid: number): string | null;
+	parse_command_line(pid: number, full_args: string): candidate_info | null;
+	// Existing (unchanged)
 	get_port_list_command(pid: number): string;
 	parse_listening_ports(stdout: string, pid: number): number[];
-	get_error_messages(): {process_not_found: string; command_not_available: string; requirements: string[]};
+	get_error_messages(): { process_not_found: string; command_not_available: string; requirements: string[] };
 }
 
 export class WindowsStrategy implements platform_strategy {
@@ -40,14 +54,26 @@ export class WindowsStrategy implements platform_strategy {
 		return false;
 	}
 
-	get_process_list_command(process_name: string): string {
+	get_process_list_commands(process_name: string): { name: string; command: string }[] {
+		// Windows: Single tier (no user-based filtering needed like Unix)
 		if (this.use_powershell) {
-			return `powershell -NoProfile -Command "Get-CimInstance Win32_Process -Filter \\"name='${process_name}'\\" | Select-Object ProcessId,CommandLine | ConvertTo-Json"`;
+			return [
+				{
+					name: 'PowerShell',
+					command: `powershell -NoProfile -Command "Get-CimInstance Win32_Process -Filter \\"name='${process_name}'\\" | Select-Object ProcessId,CommandLine | ConvertTo-Json"`,
+				},
+			];
 		}
-		return `wmic process where "name='${process_name}'" get ProcessId,CommandLine /format:list`;
+		return [
+			{
+				name: 'WMIC',
+				command: `wmic process where "name='${process_name}'" get ProcessId,CommandLine /format:list`,
+			},
+		];
 	}
 
-	parse_process_info(stdout: string): {pid: number; extension_port: number; csrf_token: string} | null {
+	parse_process_info(stdout: string): candidate_info[] {
+		const candidates: candidate_info[] = [];
 		logger.debug('WindowsStrategy', `Parsing process info (using PowerShell: ${this.use_powershell})`);
 
 		if (this.use_powershell || stdout.trim().startsWith('{') || stdout.trim().startsWith('[')) {
@@ -56,128 +82,104 @@ export class WindowsStrategy implements platform_strategy {
 			try {
 				let data = JSON.parse(stdout.trim());
 
-				if (Array.isArray(data)) {
-					logger.debug('WindowsStrategy', `JSON is an array with ${data.length} element(s)`);
-
-					if (data.length === 0) {
-						logger.warn('WindowsStrategy', `Empty process array - no language_server processes found`);
-						return null;
-					}
-
-					const total_count = data.length;
-
-					for (let i = 0; i < data.length; i++) {
-						const item = data[i];
-						logger.debug('WindowsStrategy', `Process ${i + 1}/${total_count}: PID=${item.ProcessId}`);
-						logger.debug('WindowsStrategy', `  CommandLine: ${item.CommandLine ? item.CommandLine.substring(0, 200) + '...' : '(empty)'}`);
-					}
-
-					const antigravity_processes = data.filter((item: any) => item.CommandLine && this.is_antigravity_process(item.CommandLine));
-
-					logger.info('WindowsStrategy', `Found ${total_count} language_server process(es), ${antigravity_processes.length} belong to Antigravity`);
-
-					if (antigravity_processes.length === 0) {
-						logger.warn('WindowsStrategy', `No Antigravity process found among ${total_count} language_server process(es)`);
-						logger.debug('WindowsStrategy', `Hint: Looking for processes with '--app_data_dir antigravity' or '\\antigravity\\' in path`);
-						return null;
-					}
-
-					if (total_count > 1) {
-						logger.info(
-							'WindowsStrategy',
-							`Selected Antigravity process PID: ${antigravity_processes[0].ProcessId} (first match of ${antigravity_processes.length})`
-						);
-					}
-					data = antigravity_processes[0];
-				} else {
-					logger.debug('WindowsStrategy', `JSON is a single object (PID: ${data.ProcessId})`);
-					logger.debug('WindowsStrategy', `CommandLine: ${data.CommandLine ? data.CommandLine.substring(0, 200) + '...' : '(empty)'}`);
-
-					if (!data.CommandLine || !this.is_antigravity_process(data.CommandLine)) {
-						logger.warn('WindowsStrategy', `Single process found but not Antigravity, skipping`);
-						return null;
-					}
-					logger.info('WindowsStrategy', `Found 1 Antigravity process, PID: ${data.ProcessId}`);
+				if (!Array.isArray(data)) {
+					data = [data];
 				}
 
-				const command_line = data.CommandLine || '';
-				const pid = data.ProcessId;
+				logger.debug('WindowsStrategy', `JSON has ${data.length} element(s)`);
 
-				if (!pid) {
-					logger.error('WindowsStrategy', `No PID found in process data`);
-					return null;
+				for (const item of data) {
+					if (!item.ProcessId) {
+						continue;
+					}
+
+					const pid = item.ProcessId;
+					const command_line = item.CommandLine || '';
+
+					// Check if this is an Antigravity process (if command line is available)
+					if (command_line && !this.is_antigravity_process(command_line)) {
+						continue;
+					}
+
+					// Extract port and token if available
+					const port_match = command_line.match(/--extension_server_port[=\s]+(\d+)/);
+					const token_match = command_line.match(/--csrf_token[=\s]+([a-f0-9\-]+)/i);
+
+					candidates.push({
+						pid,
+						extension_port: port_match ? parseInt(port_match[1], 10) : 0,
+						csrf_token: token_match ? token_match[1] : '',
+						command_line,
+					});
+
+					logger.debug('WindowsStrategy', `Added candidate: PID=${pid}, token=${token_match ? 'FOUND' : 'MISSING'}, cmdline=${command_line ? 'present' : 'empty'}`);
+				}
+			} catch (e: any) {
+				logger.error('WindowsStrategy', `JSON parse error: ${e.message}`);
+				logger.debug('WindowsStrategy', `Raw stdout (first 500 chars): ${stdout.substring(0, 500)}`);
+			}
+		} else {
+			// WMIC fallback parsing
+			const blocks = stdout.split(/\n\s*\n/).filter(block => block.trim().length > 0);
+			logger.debug('WindowsStrategy', `Fallback: Processing WMIC output with ${blocks.length} block(s)`);
+
+			for (const block of blocks) {
+				const pid_match = block.match(/ProcessId=(\d+)/);
+				const command_line_match = block.match(/CommandLine=(.+)/);
+
+				if (!pid_match) {
+					continue;
+				}
+
+				const pid = parseInt(pid_match[1], 10);
+				const command_line = command_line_match ? command_line_match[1].trim() : '';
+
+				if (command_line && !this.is_antigravity_process(command_line)) {
+					continue;
 				}
 
 				const port_match = command_line.match(/--extension_server_port[=\s]+(\d+)/);
 				const token_match = command_line.match(/--csrf_token[=\s]+([a-f0-9\-]+)/i);
 
-				logger.debug(
-					'WindowsStrategy',
-					`Regex matches: extension_port=${port_match ? port_match[1] : 'NOT FOUND'}, csrf_token=${token_match ? 'FOUND' : 'NOT FOUND'}`
-				);
+				candidates.push({
+					pid,
+					extension_port: port_match ? parseInt(port_match[1], 10) : 0,
+					csrf_token: token_match ? token_match[1] : '',
+					command_line,
+				});
 
-				if (!token_match || !token_match[1]) {
-					logger.error('WindowsStrategy', `CSRF token not found in command line`);
-					logger.debug('WindowsStrategy', `Full command line: ${command_line}`);
-					return null;
-				}
-
-				const extension_port = port_match && port_match[1] ? parseInt(port_match[1], 10) : 0;
-				const csrf_token = token_match[1];
-
-				logger.debug('WindowsStrategy', `Extracted: PID=${pid}, extension_port=${extension_port}, csrf_token=${csrf_token.substring(0, 8)}...`);
-
-				return {pid, extension_port, csrf_token};
-			} catch (e: any) {
-				logger.error('WindowsStrategy', `JSON parse error: ${e.message}`);
-				logger.debug('WindowsStrategy', `Raw stdout (first 500 chars): ${stdout.substring(0, 500)}`);
+				logger.debug('WindowsStrategy', `WMIC: Added candidate PID=${pid}`);
 			}
 		}
-		const blocks = stdout.split(/\n\s*\n/).filter(block => block.trim().length > 0);
 
-		logger.debug('WindowsStrategy', `Fallback: Processing WMIC output with ${blocks.length} block(s)`);
+		logger.info('WindowsStrategy', `Found ${candidates.length} Antigravity candidate(s)`);
+		return candidates;
+	}
 
-		const candidates: Array<{pid: number; extension_port: number; csrf_token: string}> = [];
+	get_full_command_line_command(pid: number): string | null {
+		// PowerShell re-query for specific PID
+		return `powershell -NoProfile -Command "Get-CimInstance Win32_Process -Filter \\"ProcessId = ${pid}\\" | Select-Object -ExpandProperty CommandLine"`;
+	}
 
-		for (const block of blocks) {
-			const pid_match = block.match(/ProcessId=(\d+)/);
-			const command_line_match = block.match(/CommandLine=(.+)/);
-
-			if (!pid_match || !command_line_match) {
-				logger.debug('WindowsStrategy', `WMIC block skipped: missing PID or CommandLine`);
-				continue;
-			}
-
-			const command_line = command_line_match[1].trim();
-			logger.debug('WindowsStrategy', `WMIC: Checking PID ${pid_match[1]}`);
-
-			if (!this.is_antigravity_process(command_line)) {
-				continue;
-			}
-
-			const port_match = command_line.match(/--extension_server_port[=\s]+(\d+)/);
-			const token_match = command_line.match(/--csrf_token[=\s]+([a-f0-9\-]+)/i);
-
-			if (!token_match || !token_match[1]) {
-				logger.debug('WindowsStrategy', `WMIC: PID ${pid_match[1]} has no CSRF token, skipping`);
-				continue;
-			}
-
-			const pid = parseInt(pid_match[1], 10);
-			const extension_port = port_match && port_match[1] ? parseInt(port_match[1], 10) : 0;
-			const csrf_token = token_match[1];
-
-			logger.debug('WindowsStrategy', `WMIC: Found candidate PID=${pid}, extension_port=${extension_port}`);
-			candidates.push({pid, extension_port, csrf_token});
-		}
-
-		if (candidates.length === 0) {
-			logger.warn('WindowsStrategy', `WMIC: No Antigravity process found`);
+	parse_command_line(pid: number, full_args: string): candidate_info | null {
+		if (!full_args || full_args.trim() === '') {
 			return null;
 		}
 
-		logger.info('WindowsStrategy', `WMIC: Found ${candidates.length} Antigravity process(es), using PID: ${candidates[0].pid}`);
-		return candidates[0];
+		const command_line = full_args.trim();
+		const port_match = command_line.match(/--extension_server_port[=\s]+(\d+)/);
+		const token_match = command_line.match(/--csrf_token[=\s]+([a-f0-9\-]+)/i);
+
+		if (!token_match) {
+			return null;
+		}
+
+		return {
+			pid,
+			extension_port: port_match ? parseInt(port_match[1], 10) : 0,
+			csrf_token: token_match[1],
+			command_line,
+		};
 	}
 
 	get_port_list_command(pid: number): string {
@@ -243,32 +245,81 @@ export class UnixStrategy implements platform_strategy {
 		this.platform = platform;
 	}
 
-	get_process_list_command(process_name: string): string {
+	get_process_list_commands(process_name: string): { name: string; command: string }[] {
+		// Tiered discovery: Tier 1 (current user), Tier 2 (global)
 		if (this.platform === 'darwin') {
-			return `pgrep -fl ${process_name}`;
+			return [
+				{ name: 'User (macOS)', command: `pgrep -u $(id -u) -fl ${process_name}` },
+				{ name: 'Global (macOS)', command: `pgrep -fl ${process_name}` },
+			];
 		}
-		return `pgrep -af ${process_name}`;
+		return [
+			{ name: 'User (Linux)', command: `pgrep -u $(id -u) -af ${process_name}` },
+			{ name: 'Global (Linux)', command: `pgrep -af ${process_name}` },
+		];
 	}
 
-	parse_process_info(stdout: string): {pid: number; extension_port: number; csrf_token: string} | null {
+	parse_process_info(stdout: string): candidate_info[] {
+		const candidates: candidate_info[] = [];
 		const lines = stdout.split('\n');
+
 		for (const line of lines) {
-			if (line.includes('--extension_server_port')) {
-				const parts = line.trim().split(/\s+/);
-				const pid = parseInt(parts[0], 10);
-				const cmd = line.substring(parts[0].length).trim();
-
-				const port_match = cmd.match(/--extension_server_port[=\s]+(\d+)/);
-				const token_match = cmd.match(/--csrf_token[=\s]+([a-zA-Z0-9\-]+)/);
-
-				return {
-					pid,
-					extension_port: port_match ? parseInt(port_match[1], 10) : 0,
-					csrf_token: token_match ? token_match[1] : '',
-				};
+			if (!line.trim()) {
+				continue;
 			}
+
+			const parts = line.trim().split(/\s+/);
+			const pid = parseInt(parts[0], 10);
+
+			if (isNaN(pid)) {
+				continue;
+			}
+
+			const cmd = line.substring(parts[0].length).trim();
+
+			// Extract port and token if available
+			const port_match = cmd.match(/--extension_server_port[=\s]+(\d+)/);
+			const token_match = cmd.match(/--csrf_token[=\s]+([a-zA-Z0-9\-]+)/);
+
+			// Return ALL PIDs, even if token is missing (crucial for macOS truncation)
+			candidates.push({
+				pid,
+				extension_port: port_match ? parseInt(port_match[1], 10) : 0,
+				csrf_token: token_match ? token_match[1] : '',
+				command_line: cmd,
+			});
+
+			logger.debug('UnixStrategy', `Added candidate: PID=${pid}, token=${token_match ? 'FOUND' : 'MISSING'}`);
 		}
-		return null;
+
+		logger.info('UnixStrategy', `Found ${candidates.length} candidate(s)`);
+		return candidates;
+	}
+
+	get_full_command_line_command(pid: number): string | null {
+		// ps -ww gives full command line on macOS/Linux
+		return `ps -ww -p ${pid} -o args=`;
+	}
+
+	parse_command_line(pid: number, full_args: string): candidate_info | null {
+		if (!full_args || full_args.trim() === '') {
+			return null;
+		}
+
+		const command_line = full_args.trim();
+		const port_match = command_line.match(/--extension_server_port[=\s]+(\d+)/);
+		const token_match = command_line.match(/--csrf_token[=\s]+([a-zA-Z0-9\-]+)/);
+
+		if (!token_match) {
+			return null;
+		}
+
+		return {
+			pid,
+			extension_port: port_match ? parseInt(port_match[1], 10) : 0,
+			csrf_token: token_match[1],
+			command_line,
+		};
 	}
 
 	get_port_list_command(pid: number): string {

--- a/src/core/process_finder.ts
+++ b/src/core/process_finder.ts
@@ -1,14 +1,16 @@
 /**
  * Process Finder Service
+ * Refactored for multi-candidate, tiered discovery with workspace-aware prioritization
  */
 
-import {exec} from 'child_process';
-import {promisify} from 'util';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import * as https from 'https';
-import {WindowsStrategy, UnixStrategy, platform_strategy} from './platform_strategies';
+import * as fs from 'fs';
+import { WindowsStrategy, UnixStrategy, platform_strategy, candidate_info } from './platform_strategies';
 import * as process from 'process';
 import * as vscode from 'vscode';
-import {logger} from '../utils/logger';
+import { logger } from '../utils/logger';
 
 const exec_async = promisify(exec);
 
@@ -19,6 +21,9 @@ export interface process_info {
 }
 
 const LOG_CAT = 'ProcessFinder';
+
+// Windows null CommandLine re-query budget (global per detection cycle)
+const NULL_REQUERY_BUDGET = 3;
 
 export class ProcessFinder {
 	private strategy: platform_strategy;
@@ -45,72 +50,105 @@ export class ProcessFinder {
 		logger.section(LOG_CAT, `Starting process detection (max_retries: ${max_retries})`);
 		const timer = logger.time_start('detect_process_info');
 
-		for (let i = 0; i < max_retries; i++) {
-			logger.debug(LOG_CAT, `Attempt ${i + 1}/${max_retries}`);
+		const checked_pids = new Set<number>();
+		let null_requery_remaining = NULL_REQUERY_BUDGET;
 
-			try {
-				const cmd = this.strategy.get_process_list_command(this.process_name);
-				logger.debug(LOG_CAT, `Executing process list command:\n${cmd}`);
+		// Get workspace paths for prioritization
+		const workspace_paths = this.get_workspace_paths();
+		const target_folder = this.get_target_folder();
 
-				const {stdout, stderr} = await exec_async(cmd);
+		logger.debug(LOG_CAT, `Target folder: ${target_folder?.uri.fsPath ?? 'none'}`);
+		logger.debug(LOG_CAT, `Workspace folders: ${workspace_paths.length}`);
 
-				if (stderr) {
-					logger.warn(LOG_CAT, `Command stderr output: ${stderr}`);
-				}
+		// Get tiered commands
+		const commands = this.strategy.get_process_list_commands(this.process_name);
+		logger.debug(LOG_CAT, `Discovery tiers: ${commands.map(c => c.name).join(', ')}`);
 
-				logger.debug(LOG_CAT, `Raw stdout (${stdout.length} chars):\n${stdout}`);
-
-				const info = this.strategy.parse_process_info(stdout);
-
-				if (info) {
-					logger.info(LOG_CAT, `Process info parsed successfully:`, {
-						pid: info.pid,
-						extension_port: info.extension_port,
-						csrf_token: `${info.csrf_token.substring(0, 8)}...`,
-					});
-
-					logger.debug(LOG_CAT, `Getting listening ports for PID: ${info.pid}`);
-					const ports = await this.get_listening_ports(info.pid);
-
-					logger.debug(LOG_CAT, `Found ${ports.length} listening port(s): [${ports.join(', ')}]`);
-
-					if (ports.length > 0) {
-						logger.debug(LOG_CAT, `Testing ports to find working endpoint...`);
-						const valid_port = await this.find_working_port(ports, info.csrf_token);
-
-						if (valid_port) {
-							logger.info(LOG_CAT, `SUCCESS: Valid port found: ${valid_port}`);
-							timer();
-							return {
-								extension_port: info.extension_port,
-								connect_port: valid_port,
-								csrf_token: info.csrf_token,
-							};
-						} else {
-							logger.warn(LOG_CAT, `No ports responded successfully to health check`);
-						}
-					} else {
-						logger.warn(LOG_CAT, `No listening ports found for PID ${info.pid}`);
-					}
-				} else {
-					logger.warn(LOG_CAT, `Failed to parse process info from command output`);
-				}
-			} catch (e: any) {
-				logger.error(LOG_CAT, `Attempt ${i + 1} failed with error:`, {
-					message: e.message,
-					code: e.code,
-					killed: e.killed,
-					signal: e.signal,
-				});
-
-				if (e.stderr) {
-					logger.error(LOG_CAT, `Command stderr: ${e.stderr}`);
-				}
+		for (let retry = 0; retry < max_retries; retry++) {
+			if (retry > 0) {
+				logger.debug(LOG_CAT, `Retry ${retry + 1}/${max_retries}`);
+				await new Promise(r => setTimeout(r, 100));
 			}
 
-			if (i < max_retries - 1) {
-				logger.debug(LOG_CAT, `Waiting 100ms before retry...`);
-				await new Promise(r => setTimeout(r, 100));
+			for (const { name: tier_name, command } of commands) {
+				logger.debug(LOG_CAT, `Tier: ${tier_name}`);
+				logger.debug(LOG_CAT, `Executing: ${command}`);
+
+				let stdout = '';
+				try {
+					const result = await exec_async(command);
+					stdout = result.stdout;
+					if (result.stderr) {
+						logger.warn(LOG_CAT, `Command stderr: ${result.stderr}`);
+					}
+				} catch (e: any) {
+					// Semantic error handling: pgrep exit code 1 = no matches (not an error)
+					if (e.code === 1 && e.signal === null && (!e.stderr || e.stderr === '')) {
+						logger.debug(LOG_CAT, `Tier ${tier_name}: No matches (exit code 1)`);
+						continue;
+					}
+					logger.error(LOG_CAT, `Tier ${tier_name} failed:`, { code: e.code, message: e.message });
+					continue;
+				}
+
+				logger.debug(LOG_CAT, `Raw stdout (${stdout.length} chars):\n${stdout.substring(0, 500)}${stdout.length > 500 ? '...' : ''}`);
+
+				// Parse candidates
+				let candidates = this.strategy.parse_process_info(stdout);
+				logger.debug(LOG_CAT, `Parsed ${candidates.length} candidate(s)`);
+
+				// Deduplicate against checked_pids
+				candidates = candidates.filter(c => !checked_pids.has(c.pid));
+				logger.debug(LOG_CAT, `After dedup: ${candidates.length} candidate(s)`);
+
+				if (candidates.length === 0) {
+					continue;
+				}
+
+				// Re-query candidates with missing tokens
+				const resolve_result = await this.resolve_missing_tokens(candidates, null_requery_remaining);
+				candidates = resolve_result.candidates;
+
+				// Update null_requery_remaining based on how many null CommandLine candidates were actually re-queried
+				null_requery_remaining = Math.max(0, null_requery_remaining - resolve_result.null_requeried);
+
+				// Filter out candidates still missing tokens
+				candidates = candidates.filter(c => c.csrf_token !== '');
+				logger.debug(LOG_CAT, `After token filter: ${candidates.length} candidate(s)`);
+
+				if (candidates.length === 0) {
+					continue;
+				}
+
+				// Prioritize candidates
+				candidates = this.prioritize_candidates(candidates, target_folder, workspace_paths);
+
+				// Health check candidates in order
+				for (const candidate of candidates) {
+					logger.debug(LOG_CAT, `Testing candidate PID=${candidate.pid}`);
+					checked_pids.add(candidate.pid);
+
+					const ports = await this.get_listening_ports(candidate.pid);
+					logger.debug(LOG_CAT, `Found ${ports.length} listening port(s): [${ports.join(', ')}]`);
+
+					if (ports.length === 0) {
+						logger.warn(LOG_CAT, `No listening ports for PID ${candidate.pid}`);
+						continue;
+					}
+
+					const valid_port = await this.find_working_port(ports, candidate.csrf_token);
+					if (valid_port) {
+						logger.info(LOG_CAT, `SUCCESS: Valid port found: ${valid_port} for PID ${candidate.pid}`);
+						timer();
+						return {
+							extension_port: candidate.extension_port,
+							connect_port: valid_port,
+							csrf_token: candidate.csrf_token,
+						};
+					} else {
+						logger.warn(LOG_CAT, `No working port for PID ${candidate.pid}`);
+					}
+				}
 			}
 		}
 
@@ -119,12 +157,184 @@ export class ProcessFinder {
 		return null;
 	}
 
+	private async resolve_missing_tokens(candidates: candidate_info[], null_budget: number): Promise<{ candidates: candidate_info[]; null_requeried: number }> {
+		const resolved: candidate_info[] = [];
+		let null_used = 0;
+
+		// Sort by PID descending for deterministic null-origin selection
+		const sorted = [...candidates].sort((a, b) => b.pid - a.pid);
+
+		for (const candidate of sorted) {
+			if (candidate.csrf_token !== '') {
+				resolved.push(candidate);
+				continue;
+			}
+
+			// Candidate needs re-query
+			const is_null_origin = candidate.command_line === '';
+
+			// Check budget for null-origin candidates
+			if (is_null_origin && null_used >= null_budget) {
+				logger.debug(LOG_CAT, `Skipping PID ${candidate.pid} (null-origin budget exhausted)`);
+				continue;
+			}
+
+			const requery_cmd = this.strategy.get_full_command_line_command(candidate.pid);
+			if (!requery_cmd) {
+				resolved.push(candidate);
+				continue;
+			}
+
+			logger.debug(LOG_CAT, `Re-querying PID ${candidate.pid}: ${requery_cmd}`);
+
+			// Count null-origin re-query BEFORE the attempt (to enforce budget globally)
+			if (is_null_origin) {
+				null_used++;
+			}
+
+			try {
+				const { stdout } = await exec_async(requery_cmd);
+				const updated = this.strategy.parse_command_line(candidate.pid, stdout);
+
+				if (updated && updated.csrf_token !== '') {
+					logger.debug(LOG_CAT, `Re-query success for PID ${candidate.pid}`);
+					resolved.push(updated);
+				} else {
+					logger.debug(LOG_CAT, `Re-query failed for PID ${candidate.pid} (no token)`);
+					// Don't add to resolved - candidate is invalid
+				}
+			} catch (e: any) {
+				logger.debug(LOG_CAT, `Re-query error for PID ${candidate.pid}: ${e.message}`);
+				// Don't add to resolved - candidate may belong to another user
+			}
+		}
+
+		return { candidates: resolved, null_requeried: null_used };
+	}
+
+	private get_workspace_paths(): { fsPath: string; realPath: string; workspace_id: string; realPath_id: string }[] {
+		const folders = vscode.workspace.workspaceFolders || [];
+		const result: { fsPath: string; realPath: string; workspace_id: string; realPath_id: string }[] = [];
+
+		for (const folder of folders) {
+			if (folder.uri.scheme !== 'file') {
+				continue;
+			}
+
+			const fsPath = folder.uri.fsPath;
+			let realPath = fsPath;
+
+			try {
+				realPath = fs.realpathSync(fsPath);
+			} catch {
+				// Fall back to original path
+			}
+
+			result.push({
+				fsPath,
+				realPath,
+				workspace_id: this.derive_workspace_id(fsPath),
+				realPath_id: this.derive_workspace_id(realPath),
+			});
+		}
+
+		return result;
+	}
+
+	private get_target_folder(): vscode.WorkspaceFolder | undefined {
+		// Use active editor's workspace folder if available
+		const editor = vscode.window.activeTextEditor;
+		if (editor) {
+			const folder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+			if (folder) {
+				return folder;
+			}
+		}
+		// Fallback to first workspace folder
+		return vscode.workspace.workspaceFolders?.[0];
+	}
+
+	private derive_workspace_id(fsPath: string): string {
+		// Note: Leading "/" on Unix becomes "_", so /home/foo → file__home_foo (double underscore is intentional)
+		let normalized = fsPath.replace(/[/\\:]/g, '_');
+		if (process.platform === 'win32') {
+			normalized = normalized.toLowerCase();
+		}
+		return 'file_' + normalized;
+	}
+
+	private prioritize_candidates(
+		candidates: candidate_info[],
+		target_folder: vscode.WorkspaceFolder | undefined,
+		workspace_paths: { fsPath: string; realPath: string; workspace_id: string; realPath_id: string }[]
+	): candidate_info[] {
+		// Get target folder paths (if any)
+		let target_paths: string[] = [];
+		let target_ids: string[] = [];
+
+		if (target_folder && target_folder.uri.scheme === 'file') {
+			const fsPath = target_folder.uri.fsPath;
+			let realPath = fsPath;
+			try {
+				realPath = fs.realpathSync(fsPath);
+			} catch {
+				// Fall back to original
+			}
+			target_paths = [fsPath, realPath];
+			target_ids = [this.derive_workspace_id(fsPath), this.derive_workspace_id(realPath)];
+		}
+
+		// Compute all workspace paths and IDs
+		const all_paths = workspace_paths.flatMap(w => [w.fsPath, w.realPath]);
+		const all_ids = workspace_paths.flatMap(w => [w.workspace_id, w.realPath_id]);
+
+		// Helper for path matching (case-insensitive on Windows)
+		const pathIncludes = (cmd: string, path: string): boolean => {
+			if (process.platform === 'win32') {
+				return cmd.toLowerCase().includes(path.toLowerCase());
+			}
+			return cmd.includes(path);
+		};
+
+		// Score and sort candidates
+		const scored = candidates.map(candidate => {
+			let weight = 0;
+
+			// Weight 100: Matches target folder
+			if (target_paths.some(p => pathIncludes(candidate.command_line, p))) {
+				weight = 100;
+			}
+			// Weight 50: Matches any workspace folder
+			else if (all_paths.some(p => pathIncludes(candidate.command_line, p))) {
+				weight = 50;
+			}
+			// Weight 10: Matches any workspace_id (also case-insensitive on Windows)
+			else if (all_ids.some(id => pathIncludes(candidate.command_line, id))) {
+				weight = 10;
+			}
+
+			return { candidate, weight };
+		});
+
+		// Sort by weight descending, then PID descending
+		scored.sort((a, b) => {
+			if (b.weight !== a.weight) {
+				return b.weight - a.weight;
+			}
+			return b.candidate.pid - a.candidate.pid;
+		});
+
+		logger.debug(LOG_CAT, `Prioritized candidates: ${scored.map(s => `PID=${s.candidate.pid}(w=${s.weight})`).join(', ')}`);
+
+		return scored.map(s => s.candidate);
+	}
+
 	private async get_listening_ports(pid: number): Promise<number[]> {
 		try {
 			const cmd = this.strategy.get_port_list_command(pid);
 			logger.debug(LOG_CAT, `Port list command:\n${cmd}`);
 
-			const {stdout, stderr} = await exec_async(cmd);
+			const { stdout, stderr } = await exec_async(cmd);
 
 			if (stderr) {
 				logger.warn(LOG_CAT, `Port list stderr: ${stderr}`);
@@ -209,7 +419,7 @@ export class ProcessFinder {
 				resolve(false);
 			});
 
-			req.write(JSON.stringify({wrapper_data: {}}));
+			req.write(JSON.stringify({ wrapper_data: {} }));
 			req.end();
 		});
 	}


### PR DESCRIPTION
## Summary

This PR implements a production-grade fix for process detection that handles shared Linux/macOS/Windows environments where multiple users or VS Code instances run the language server process.

## Problem

On shared Linux servers, the extension would incorrectly select a language_server process belonging to a different user, then fail with permission errors when attempting to query ports.

## Solution

### Tiered Discovery
- **Tier 1 (User)**: `pgrep -u $(id -u)` searches only processes owned by the current user
- **Tier 2 (Global)**: Fallback to all processes if Tier 1 yields no working server

### Multi-Candidate Iteration
- Returns ALL matching PIDs instead of just the first
- Tests candidates in priority order until finding a working one

### Workspace-Aware Prioritization
| Weight | Match Type |
|--------|------------|
| 100 | Active editor's workspace folder |
| 50 | Any open workspace folder |
| 10 | Derived workspace_id in command line |

Secondary sort by PID descending (prefer newer processes).

### Robust Token Resolution
- Per-PID re-query via `ps -ww` (Unix) or PowerShell (Windows) when tokens are truncated
- Global budget of 3 for null-origin re-queries on Windows

### Cross-Platform Path Matching
- Case-insensitive path and workspace_id matching on Windows
- Dual-path matching (raw + realpath) for symlink resilience

## Files Changed

- `src/core/platform_strategies.ts` - New multi-candidate interface
- `src/core/process_finder.ts` - Tiered discovery and prioritization
- `CHANGELOG.md` - Version 1.2.0 release notes
- `package.json` - Version bump

## Testing

- [x] TypeScript compilation passes
- [x] Manual testing on shared Linux server
- [x] Manual testing on macOS (truncation scenario)
- [ ] Manual testing on Windows (null CommandLine scenario)