### PR TITLE
Fix mac process detection

### DIFF
--- a/src/core/process_finder.ts
+++ b/src/core/process_finder.ts
@@ -32,7 +32,7 @@ export class ProcessFinder {
 			this.process_name = 'language_server_windows_x64.exe';
 		} else if (process.platform === 'darwin') {
 			this.strategy = new UnixStrategy('darwin');
-			this.process_name = `language_server_macos${process.arch === 'arm64' ? '_arm' : ''}`;
+			this.process_name = `language_server_macos_${process.arch === 'arm64' ? 'arm64' : 'x64'}`;
 		} else {
 			this.strategy = new UnixStrategy('linux');
 			this.process_name = `language_server_linux${process.arch === 'arm64' ? '_arm' : '_x64'}`;
@@ -52,7 +52,7 @@ export class ProcessFinder {
 				const cmd = this.strategy.get_process_list_command(this.process_name);
 				logger.debug(LOG_CAT, `Executing process list command:\n${cmd}`);
 
-				const {stdout, stderr} = await exec_async(cmd);
+				const { stdout, stderr } = await exec_async(cmd);
 
 				if (stderr) {
 					logger.warn(LOG_CAT, `Command stderr output: ${stderr}`);
@@ -124,7 +124,7 @@ export class ProcessFinder {
 			const cmd = this.strategy.get_port_list_command(pid);
 			logger.debug(LOG_CAT, `Port list command:\n${cmd}`);
 
-			const {stdout, stderr} = await exec_async(cmd);
+			const { stdout, stderr } = await exec_async(cmd);
 
 			if (stderr) {
 				logger.warn(LOG_CAT, `Port list stderr: ${stderr}`);
@@ -209,7 +209,7 @@ export class ProcessFinder {
 				resolve(false);
 			});
 
-			req.write(JSON.stringify({wrapper_data: {}}));
+			req.write(JSON.stringify({ wrapper_data: {} }));
 			req.end();
 		});
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,7 +130,7 @@ async function initialize_extension() {
 
 	try {
 		logger.info('Extension', 'Detecting Antigravity process...');
-		const process_info = await process_finder.detect_process_info();
+		const process_info = await process_finder.detect_process_info(5);
 
 		if (process_info) {
 			logger.info('Extension', 'Process found successfully', {


### PR DESCRIPTION
This pull request makes two targeted improvements: it corrects the naming convention for the macOS language server binary to be more explicit about architecture, and it specifies a timeout value when detecting the Antigravity process during extension initialization.

Platform-specific process detection:

* Updated the macOS process name in `ProcessFinder` to use the explicit format `language_server_macos_arm64` or `language_server_macos_x64` based on architecture, improving clarity and consistency.

Extension initialization:

* Modified the call to `detect_process_info` in `initialize_extension` to include a timeout value of 5 seconds, making process detection behavior more predictable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS process detection compatibility by updating executable identification.
  * Enhanced process detection with timeout handling for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->