### PR TITLE
add arm64 arch for win32 process finder

### DIFF
--- a/src/core/process_finder.ts
+++ b/src/core/process_finder.ts
@@ -29,7 +29,7 @@ export class ProcessFinder {
 
 		if (process.platform === 'win32') {
 			this.strategy = new WindowsStrategy();
-			this.process_name = 'language_server_windows_x64.exe';
+			this.process_name = `language_server_windows_${process.arch === 'arm64' ? 'arm' : 'x64'}.exe`;
 		} else if (process.platform === 'darwin') {
 			this.strategy = new UnixStrategy('darwin');
 			this.process_name = `language_server_macos${process.arch === 'arm64' ? '_arm' : ''}`;


### PR DESCRIPTION
Update for the process finder core code to look for the arm64 arch version of the language server under win32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility: the application now selects the correct architecture-specific language server executable on Windows (ARM64 vs x64), ensuring the proper binary is used automatically and improving reliability on Windows ARM64 devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->