### PR TITLE
use correct abbreviation for Gemini models 

### DIFF
--- a/src/ui/status_bar.ts
+++ b/src/ui/status_bar.ts
@@ -8,8 +8,8 @@ import {quota_snapshot, model_quota_info} from '../utils/types';
 /** Mapping of model labels to short abbreviations for status bar display */
 const MODEL_ABBREVIATIONS: Record<string, string> = {
 	'Gemini 3 Pro (High)': 'Gemini 3 Pro (H)',
-	'Gemini 3 Pro (Low)': 'Gemini 3 Pro (L)',
-	'Gemini 3 Flash': 'Gemini 3 Flash',
+	'Gemini 3 Pro (Low)': 'Gemini 3PL',
+	'Gemini 3 Flash': 'Gemini 3F',
 	'Claude Sonnet 4.5': 'Claude S4.5',
 	'Claude Sonnet 4.5 (Thinking)': 'Claude S4.5T',
 	'Claude Opus 4.5 (Thinking)': 'Claude O4.5T',


### PR DESCRIPTION
Hi 

Thanks for the extension! 

Currently, the status bar is not using abbreviation for Gemini 3 Flash model. 

It is distinctly showing unabbreviated form unlike for the other models. 

<img width="551" height="74" alt="image" src="https://github.com/user-attachments/assets/c7a81853-176c-4d5b-8c33-d82ee4d9e9fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated abbreviation labels in the status bar to improve readability and consistency across model displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->